### PR TITLE
Feat: 멀티모드 방 생성시 최대 인원수 변경 가능 기능 구현

### DIFF
--- a/backend/src/main/java/com/a608/musiq/domain/websocket/data/GameRoomUserNumber.java
+++ b/backend/src/main/java/com/a608/musiq/domain/websocket/data/GameRoomUserNumber.java
@@ -1,0 +1,15 @@
+package com.a608.musiq.domain.websocket.data;
+
+import lombok.Getter;
+
+@Getter
+public enum GameRoomUserNumber {
+    MINIMUM_USER_NUMBER(1),
+    MAX_USER_NUMBER(10);
+
+    private int value;
+
+    GameRoomUserNumber(int value) {
+        this.value = value;
+    }
+}

--- a/backend/src/main/java/com/a608/musiq/domain/websocket/domain/GameRoom.java
+++ b/backend/src/main/java/com/a608/musiq/domain/websocket/domain/GameRoom.java
@@ -32,7 +32,6 @@ import lombok.NoArgsConstructor;
 public class GameRoom {
     private static final int LEAST_MEMBER_SIZE = 1;
     private static final int ROOM_DIVIDE_NUMBER = 1000;
-    private static final int MAX_ROOM_USER = 6;
     private static final int MULTI_MODE_EXP_WEIGHT = 10;
     private static final String SPACE = " ";
 
@@ -50,6 +49,8 @@ public class GameRoom {
 
     //선택한 연도
     private String year;
+
+    private int maxUserNumber;
 
     private String roomManagerNickname;
 
@@ -184,7 +185,7 @@ public class GameRoom {
             throw new MultiModeException(MultiModeExceptionInfo.ALREADY_STARTED_ROOM);
         }
 
-        if (totalUsers == MAX_ROOM_USER) {
+        if (totalUsers == this.maxUserNumber) {
             throw new MultiModeException(MultiModeExceptionInfo.FULL_ROOM_USER);
         }
 

--- a/backend/src/main/java/com/a608/musiq/domain/websocket/domain/log/MultiModeCreateGameRoomLog.java
+++ b/backend/src/main/java/com/a608/musiq/domain/websocket/domain/log/MultiModeCreateGameRoomLog.java
@@ -41,6 +41,10 @@ public class MultiModeCreateGameRoomLog {
 
 	@NotNull
 	@Column
+	private int maxUserNumber;
+
+	@NotNull
+	@Column
 	private Boolean isStarted;
 
 	@NotNull

--- a/backend/src/main/java/com/a608/musiq/domain/websocket/dto/requestDto/CreateGameRoomRequestDto.java
+++ b/backend/src/main/java/com/a608/musiq/domain/websocket/dto/requestDto/CreateGameRoomRequestDto.java
@@ -19,5 +19,6 @@ public class CreateGameRoomRequestDto {
     private String roomName;
     private String password;
     private String musicYear;
+    private int maxUserNumber;
     private int quizAmount;
 }

--- a/backend/src/main/java/com/a608/musiq/domain/websocket/service/GameService.java
+++ b/backend/src/main/java/com/a608/musiq/domain/websocket/service/GameService.java
@@ -2,11 +2,7 @@ package com.a608.musiq.domain.websocket.service;
 
 import com.a608.musiq.domain.member.domain.MemberInfo;
 import com.a608.musiq.domain.member.repository.MemberInfoRepository;
-import com.a608.musiq.domain.websocket.data.GameRoomType;
-import com.a608.musiq.domain.websocket.data.GameValue;
-import com.a608.musiq.domain.websocket.data.MessageDtoType;
-import com.a608.musiq.domain.websocket.data.MessageType;
-import com.a608.musiq.domain.websocket.data.PlayType;
+import com.a608.musiq.domain.websocket.data.*;
 import com.a608.musiq.domain.websocket.domain.Channel;
 import com.a608.musiq.domain.websocket.domain.GameRoom;
 import com.a608.musiq.domain.websocket.domain.UserInfoItem;
@@ -549,6 +545,9 @@ public class GameService {
 		userInfoItems.put(uuid,
 			UserInfoItem.builder().nickname(memberInfo.getNickname()).score(0.0)
 				.isSkipped(false).build());
+
+		validateMaxUserNumber(createGameRoomRequestDto.getMaxUserNumber());
+
 		GameRoom gameRoom = GameRoom.builder().roomNo(roomNumber)
 			.roomName(createGameRoomRequestDto.getRoomName())
 			.password(createGameRoomRequestDto.getPassword())
@@ -557,6 +556,7 @@ public class GameService {
 			.roomManagerNickname(memberInfo.getNickname())
 			.numberOfProblems(createGameRoomRequestDto.getQuizAmount())
 			.year(createGameRoomRequestDto.getMusicYear())
+			.maxUserNumber(createGameRoomRequestDto.getMaxUserNumber())
 			.totalUsers(0)
 			.gameRoomType(GameRoomType.WAITING)
 			.userInfoItems(userInfoItems).build();
@@ -692,6 +692,7 @@ public class GameService {
 		return multiModeCreateGameRoomLogRepository.save(MultiModeCreateGameRoomLog.builder()
 				.title(createGameRoomRequestDto.getRoomName())
 				.years(createGameRoomRequestDto.getMusicYear())
+				.maxUserNumber(createGameRoomRequestDto.getMaxUserNumber())
 				.roomManagerNickname(nickname)
 				.password(createGameRoomRequestDto.getPassword())
 				.isStarted(Boolean.FALSE)
@@ -791,6 +792,13 @@ public class GameService {
 		return multiModeGameStartLogRepository.findLatestStartedAtByMultiModeCreateGameRoomLogId(
 				gameOverRequestDto.getMultiModeCreateGameRoomLogId())
 			.orElseThrow(() -> new MultiModeException(MultiModeExceptionInfo.NOT_FOUND_MULTI_MODE_GAME_START_LOG));
+	}
+
+	private void validateMaxUserNumber(int maxUserNumber) {
+		if (GameRoomUserNumber.MINIMUM_USER_NUMBER.getValue() > maxUserNumber
+			|| GameRoomUserNumber.MAX_USER_NUMBER.getValue() < maxUserNumber) {
+			throw new MultiModeException(MultiModeExceptionInfo.INVALID_MAX_USER_NUMBER);
+		}
 	}
 
 }

--- a/backend/src/main/java/com/a608/musiq/global/exception/info/MultiModeExceptionInfo.java
+++ b/backend/src/main/java/com/a608/musiq/global/exception/info/MultiModeExceptionInfo.java
@@ -11,7 +11,8 @@ public enum MultiModeExceptionInfo {
     ALREADY_STARTED_ROOM(HttpStatus.BAD_REQUEST, 1603, "이미 시작한 방입니다."),
     WRONG_PASSWORD(HttpStatus.BAD_REQUEST, 1604, "비밀번호가 일치하지 않습니다."),
     NOT_FOUND_MULTI_MODE_CREATE_GAME_ROOM_LOG(HttpStatus.BAD_REQUEST, 1605, "멀티모드 게임방 생성 로그를 찾을 수 없습니다."),
-    NOT_FOUND_MULTI_MODE_GAME_START_LOG(HttpStatus.BAD_REQUEST, 1606, "멀티모드 게임 시작 로그를 찾을 수 없습니다.");
+    NOT_FOUND_MULTI_MODE_GAME_START_LOG(HttpStatus.BAD_REQUEST, 1606, "멀티모드 게임 시작 로그를 찾을 수 없습니다."),
+    INVALID_MAX_USER_NUMBER(HttpStatus.BAD_REQUEST, 1607, "최대 인원수가 유효하지 않습니다.");
 
     private final HttpStatus status;
     private final Integer code;


### PR DESCRIPTION
### 1️⃣ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
<br>

### 2️⃣ 이슈 번호
close #7 
<br>
<br>

### 3️⃣ 변경 사항
- 멀티모드 방 생성시 방 최대 인원수를 사용자가 변경할 수 있도록 기능 추가했습니다.
- 기존 방생성 API 호출시 Request Dto에 maxUserNumber 라는 int 변수에 최소 1에서 10까지의 수를 담아야 합니다.
- [게임 방 생성 API 변경 - requestDto의 maxUserNumber 추가](https://www.notion.so/API-bb41f8c1032d4d9eae277dd522f42f21?p=b5f57a8822114fc18e5dd2549f4c030b&pm=s)
<br>
<br>

### 4️⃣ 테스트 결과
운영 DB에 postman으로 직접 API호출을 통한 테스트에서는 성공적으로 maxUserNumber가 적용되었습니다.
