### PR TITLE
Chore: Add Music Problem Amount In CreateGameRoomLog

### DIFF
--- a/backend/src/main/java/com/a608/musiq/domain/websocket/domain/log/MultiModeCreateGameRoomLog.java
+++ b/backend/src/main/java/com/a608/musiq/domain/websocket/domain/log/MultiModeCreateGameRoomLog.java
@@ -45,6 +45,10 @@ public class MultiModeCreateGameRoomLog {
 
 	@NotNull
 	@Column
+	private int quizAmount;
+
+	@NotNull
+	@Column
 	private Boolean isStarted;
 
 	@NotNull

--- a/backend/src/main/java/com/a608/musiq/domain/websocket/service/GameService.java
+++ b/backend/src/main/java/com/a608/musiq/domain/websocket/service/GameService.java
@@ -518,7 +518,6 @@ public class GameService {
 						.gameRoomNo(subscribeNo)
 						.roomTitle(gameRoom.getRoomName())
 						.roomManager(roomManager.getNickname())
-						.maxUserNumber(gameRoom.getMaxUserNumber())
 						.currentMembers(gameRoom.getTotalUsers())
 						.currentRound(gameRoom.getRound())
 						.quizAmount(gameRoom.getNumberOfProblems())
@@ -547,7 +546,7 @@ public class GameService {
 			UserInfoItem.builder().nickname(memberInfo.getNickname()).score(0.0)
 				.isSkipped(false).build());
 
-//		validateMaxUserNumber(createGameRoomRequestDto.getMaxUserNumber());
+		validateMaxUserNumber(createGameRoomRequestDto.getMaxUserNumber());
 
 		GameRoom gameRoom = GameRoom.builder().roomNo(roomNumber)
 			.roomName(createGameRoomRequestDto.getRoomName())
@@ -557,7 +556,7 @@ public class GameService {
 			.roomManagerNickname(memberInfo.getNickname())
 			.numberOfProblems(createGameRoomRequestDto.getQuizAmount())
 			.year(createGameRoomRequestDto.getMusicYear())
-			.maxUserNumber(6)
+			.maxUserNumber(createGameRoomRequestDto.getMaxUserNumber())
 			.totalUsers(0)
 			.gameRoomType(GameRoomType.WAITING)
 			.userInfoItems(userInfoItems).build();
@@ -693,8 +692,8 @@ public class GameService {
 		return multiModeCreateGameRoomLogRepository.save(MultiModeCreateGameRoomLog.builder()
 				.title(createGameRoomRequestDto.getRoomName())
 				.years(createGameRoomRequestDto.getMusicYear())
-//				.maxUserNumber(createGameRoomRequestDto.getMaxUserNumber())
-				.maxUserNumber(6)
+				.maxUserNumber(createGameRoomRequestDto.getMaxUserNumber())
+				.quizAmount(createGameRoomRequestDto.getQuizAmount())
 				.roomManagerNickname(nickname)
 				.password(createGameRoomRequestDto.getPassword())
 				.isStarted(Boolean.FALSE)


### PR DESCRIPTION
### 1️⃣ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
<br>

### 2️⃣ 이슈 번호
#8  
<br>
<br>

### 3️⃣ 변경 사항
- MultiModeCreateGameRoomLog에 문제 수를 저장하도록 변경했습니다.
- 기존에 게임방 생성시 넘겨주던 quizAmount의 값을 저장하기 때문에 Dto 변경은 없습니다.
- [게임 방 생성 API](https://www.notion.so/API-bb41f8c1032d4d9eae277dd522f42f21?p=b5f57a8822114fc18e5dd2549f4c030b&pm=s)
<br>
<br>

### 4️⃣ 테스트 결과
- devDB와 postman으로 테스트 결과 이상없습니다.