### PR TITLE
Feat: 추가 싱글모드 다음 라운드 기능

### DIFF
--- a/backend/src/main/java/com/a608/musiq/domain/music/controller/SingleModeMusicV2Controller.java
+++ b/backend/src/main/java/com/a608/musiq/domain/music/controller/SingleModeMusicV2Controller.java
@@ -4,12 +4,9 @@ import com.a608.musiq.domain.music.dto.requestDto.AddIpInLogRequestDto;
 import com.a608.musiq.domain.music.dto.responseDto.*;
 import com.a608.musiq.domain.music.dto.responseDto.v2.*;
 import com.a608.musiq.domain.music.dto.serviceDto.CreateRoomRequestServiceDto;
-import com.a608.musiq.domain.music.service.GuestModeMusicService;
 import com.a608.musiq.domain.music.service.SingleModeMusicService;
 import com.a608.musiq.global.common.response.BaseResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -62,11 +59,11 @@ public class SingleModeMusicV2Controller {
 	 * @return
 	 */
 	@GetMapping("/resumption")
-	private ResponseEntity<BaseResponse<GameStartResponseDto>> ResumePrevGameRoom(
+	private ResponseEntity<BaseResponse<RoundInfoResponseDto>> ResumePrevGameRoom(
 			@RequestHeader("accessToken") String token
 	) {
 		return ResponseEntity.status(HttpStatus.OK)
-				.body(BaseResponse.<GameStartResponseDto>builder()
+				.body(BaseResponse.<RoundInfoResponseDto>builder()
 						.code(HttpStatus.OK.value())
 						.data(musicService.resumePrevGame(token))
 						.build());
@@ -80,13 +77,13 @@ public class SingleModeMusicV2Controller {
 	 * @return
 	 */
 	@PostMapping("/room")
-	private ResponseEntity<BaseResponse<GameStartResponseDto>> createRoom(
+	private ResponseEntity<BaseResponse<RoundInfoResponseDto>> createRoom(
 		@RequestParam("difficulty") String difficulty,
 		@RequestParam("year") String year,
 		@RequestHeader("accessToken") String token
 	) {
 		return ResponseEntity.status(HttpStatus.OK)
-			.body(BaseResponse.<GameStartResponseDto>builder()
+			.body(BaseResponse.<RoundInfoResponseDto>builder()
 				.code(HttpStatus.OK.value())
 				.data(musicService.startNewGame(CreateRoomRequestServiceDto.from(difficulty, year, token)))
 				.build());
@@ -160,6 +157,23 @@ public class SingleModeMusicV2Controller {
 				.body(BaseResponse.<SingleRoundEndResponseDto>builder()
 						.code(HttpStatus.OK.value())
 						.data(musicService.endRound(token))
+						.build());
+	}
+
+	/**
+	 * 다음 라운드 정보 받기
+	 *
+	 * @param token
+	 * @return
+	 */
+	@GetMapping("/nextround")
+	private ResponseEntity<BaseResponse<RoundInfoResponseDto>> goNextRound(
+			@RequestHeader("accessToken") String token
+	) {
+		return ResponseEntity.status(HttpStatus.OK)
+				.body(BaseResponse.<RoundInfoResponseDto>builder()
+						.code(HttpStatus.OK.value())
+						.data(musicService.nextRound(token))
 						.build());
 	}
 

--- a/backend/src/main/java/com/a608/musiq/domain/music/domain/SingleGameRoom.java
+++ b/backend/src/main/java/com/a608/musiq/domain/music/domain/SingleGameRoom.java
@@ -59,11 +59,11 @@ public class SingleGameRoom {
 			.build();
 	}
 
-	public void addRound(Integer round) {
-		if (this.round != round) {
-			throw new MusicException(MusicExceptionInfo.INVALID_ROUND);
-		}
-		this.round = round + 1;
+	public void goNextRound() {
+		this.round++;
+		this.listenNum = LISTEN_NUM_START_NUMBER;
+		this.tryNum = TRY_NUM_START_NUMBER;
+		isRoundEnded = IS_ROUND_ENDED_START;
 	}
 
 	public void minusListenNum() {

--- a/backend/src/main/java/com/a608/musiq/domain/music/dto/responseDto/v2/RoundInfoResponseDto.java
+++ b/backend/src/main/java/com/a608/musiq/domain/music/dto/responseDto/v2/RoundInfoResponseDto.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class GameStartResponseDto {
+public class RoundInfoResponseDto {
     private String difficulty;
     private Integer round;
     private Integer life;
@@ -13,8 +13,8 @@ public class GameStartResponseDto {
     private Integer listenNum;
     private String musicUrl;
 
-    public static GameStartResponseDto from(String difficulty, Integer round, Integer life, Integer tryNum, Integer listenNum, String musicUrl) {
-        return GameStartResponseDto.builder()
+    public static RoundInfoResponseDto from(String difficulty, Integer round, Integer life, Integer tryNum, Integer listenNum, String musicUrl) {
+        return RoundInfoResponseDto.builder()
                 .difficulty(difficulty)
                 .round(round)
                 .life(life)

--- a/backend/src/main/java/com/a608/musiq/domain/music/dto/responseDto/v2/SingleRoundEndResponseDto.java
+++ b/backend/src/main/java/com/a608/musiq/domain/music/dto/responseDto/v2/SingleRoundEndResponseDto.java
@@ -11,13 +11,16 @@ public class SingleRoundEndResponseDto {
     private String singer;
     private Integer round;
     private Integer life;
+    private Boolean isGameOver;
 
-    public static SingleRoundEndResponseDto from(String title, String singer, Integer round, Integer life) {
+    public static SingleRoundEndResponseDto from(String title, String singer, Integer round, Integer life,
+                                                 Boolean isGameOver) {
         return SingleRoundEndResponseDto.builder()
                 .title(title)
                 .singer(singer)
                 .round(round)
                 .life(life)
+                .isGameOver(isGameOver)
                 .build();
     }
 }

--- a/backend/src/main/java/com/a608/musiq/domain/music/service/SingleModeMusicService.java
+++ b/backend/src/main/java/com/a608/musiq/domain/music/service/SingleModeMusicService.java
@@ -16,10 +16,10 @@ public interface SingleModeMusicService {
     DeletePrevGameResponseDto deletePrevGame(String token);
 
     // 진행 중인 게임 이어하기
-    GameStartResponseDto resumePrevGame(String token);
+    RoundInfoResponseDto resumePrevGame(String token);
 
     // 새로운 게임 시작하기
-    GameStartResponseDto startNewGame(CreateRoomRequestServiceDto createRoomRequestServiceDto);
+    RoundInfoResponseDto startNewGame(CreateRoomRequestServiceDto createRoomRequestServiceDto);
 
     // 노래 재생 가능 여부 확인
     MusicPlayCheckResponseDto checkMusicPlay(String token);
@@ -32,4 +32,7 @@ public interface SingleModeMusicService {
 
     // 라운드 종료
     SingleRoundEndResponseDto endRound(String token);
+
+    // 다음 라운드
+    RoundInfoResponseDto nextRound(String token);
 }

--- a/backend/src/main/java/com/a608/musiq/global/exception/info/SingleModeExceptionInfo.java
+++ b/backend/src/main/java/com/a608/musiq/global/exception/info/SingleModeExceptionInfo.java
@@ -8,7 +8,8 @@ import lombok.Getter;
 public enum SingleModeExceptionInfo {
 	NOT_FOUND_LOG(HttpStatus.NOT_FOUND, 1500, "게임방을 찾을 수 없습니다."),
 	ENDED_ROUND(HttpStatus.NOT_ACCEPTABLE, 1501, "종료된 라운드입니다."),
-	ONGOING_ROUND(HttpStatus.NOT_ACCEPTABLE, 1502, "종료되지 않은 라운드입니다.");
+	ONGOING_ROUND(HttpStatus.NOT_ACCEPTABLE, 1502, "종료되지 않은 라운드입니다."),
+	GAME_OVER(HttpStatus.NOT_ACCEPTABLE, 1503, "더 이상 진행할 수 없습니다.");
 
 	private final HttpStatus status;
 	private final Integer code;


### PR DESCRIPTION
### 1️⃣ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
<br>

### 2️⃣ 이슈 번호
close #31 
<br>

### 3️⃣ 변경 사항
- 다음 라운드 호출 시점 확정을 위해 RoundEndResponseDto에 isGameOver 추가
- 기존 GameStartResponseDto를 RoundInfoResponseDto로 rename
- 다음 라운드 관련 Dto추가 및 Service, Controller 메서드 추가
<br>

### 4️⃣ 테스트 결과
포스트맨으로 테스트 완료
