### PR TITLE
Fix: maxUserNumber 6으로 고정시킨 코드 복구

### DIFF
--- a/backend/src/main/java/com/a608/musiq/domain/websocket/service/GameService.java
+++ b/backend/src/main/java/com/a608/musiq/domain/websocket/service/GameService.java
@@ -526,7 +526,7 @@ public class GameService {
 			UserInfoItem.builder().nickname(memberInfo.getNickname()).score(0.0)
 				.isSkipped(false).build());
 
-//		validateMaxUserNumber(createGameRoomRequestDto.getMaxUserNumber());
+		validateMaxUserNumber(createGameRoomRequestDto.getMaxUserNumber());
 
 		GameRoom gameRoom = GameRoom.builder().roomNo(roomNumber)
 			.title(createGameRoomRequestDto.getRoomName())
@@ -536,8 +536,7 @@ public class GameService {
 			.roomManagerNickname(memberInfo.getNickname())
 			.numberOfProblems(createGameRoomRequestDto.getQuizAmount())
 			.year(createGameRoomRequestDto.getMusicYear())
-			.maxUserNumber(6)
-//			.maxUserNumber(createGameRoomRequestDto.getMaxUserNumber())
+			.maxUserNumber(createGameRoomRequestDto.getMaxUserNumber())
 			.totalUsers(0)
 			.gameRoomType(GameRoomType.WAITING)
 			.userInfoItems(userInfoItems).build();
@@ -673,8 +672,7 @@ public class GameService {
 		return multiModeCreateGameRoomLogRepository.save(MultiModeCreateGameRoomLog.builder()
 				.title(createGameRoomRequestDto.getRoomName())
 				.years(createGameRoomRequestDto.getMusicYear())
-//				.maxUserNumber(createGameRoomRequestDto.getMaxUserNumber())
-				.maxUserNumber(6)
+				.maxUserNumber(createGameRoomRequestDto.getMaxUserNumber())
 				.quizAmount(createGameRoomRequestDto.getQuizAmount())
 				.roomManagerNickname(nickname)
 				.password(createGameRoomRequestDto.getPassword())


### PR DESCRIPTION
### 1️⃣ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
<br>

### 2️⃣ 이슈 번호
- close #40
<br>
<br>

### 3️⃣ 변경 사항
- 이전에 최대 인원수 변경시 6으로 고정했던 값 제대로 동작하도록 복구
- 1~10 의 값만 가능하도록 유효성 검사 기능 추가
<br>
<br>

### 4️⃣ 테스트 결과
- postman으로 테스트 완료했습니다.
