### PR TITLE
Feat: 게임방 정보 변경 유효성 검사 기능 구현

### DIFF
--- a/backend/src/main/java/com/a608/musiq/domain/websocket/data/GameRoomInformation.java
+++ b/backend/src/main/java/com/a608/musiq/domain/websocket/data/GameRoomInformation.java
@@ -1,0 +1,21 @@
+package com.a608.musiq.domain.websocket.data;
+
+import lombok.Getter;
+
+@Getter
+public enum GameRoomInformation {
+    MINIMUM_TITLE_LENGTH(1),
+    MAXIMUM_TITLE_LENGTH(18),
+    QUIZ_AMOUNT_3(3),
+    QUIZ_AMOUNT_10(10),
+    QUIZ_AMOUNT_20(20),
+    QUIZ_AMOUNT_30(30),
+    MINIMUM_MAX_USER_NUMBER(1),
+    MAXIMUM_MAX_USER_NUMBER(10);
+
+    private int value;
+
+    GameRoomInformation(int value) {
+        this.value = value;
+    }
+}

--- a/backend/src/main/java/com/a608/musiq/domain/websocket/service/GameService.java
+++ b/backend/src/main/java/com/a608/musiq/domain/websocket/service/GameService.java
@@ -798,6 +798,9 @@ public class GameService {
 
 		GameRoom gameRoom = GameValue.getGameRooms().get(modifyGameRoomInformationRequestDto.getGameRoomNo());
 
+		// 게임방에서 정보 변경
+		gameRoom.modifyInformation(modifyGameRoomInformationRequestDto);
+
 		// log에 변경 내용 저장
 		multiModeModifyGameRoomInformationLogRepository.save(
 			MultiModeModifyGameRoomInformationLog.builder()
@@ -812,9 +815,6 @@ public class GameService {
 				.modifiedMaxUserNumber(modifyGameRoomInformationRequestDto.getMaxUserNumber())
 				.build()
 		);
-
-		// 게임방에서 정보 변경
-		gameRoom.modifyInformation(modifyGameRoomInformationRequestDto);
 
 		// 퍼블리시
 		String destination = getDestination(modifyGameRoomInformationRequestDto.getGameRoomNo());
@@ -851,6 +851,33 @@ public class GameService {
 
 		if (!gameRoom.getGameRoomType().equals(GameRoomType.WAITING)) {
 			throw new MultiModeException(MultiModeExceptionInfo.ALREADY_STARTED_ROOM);
+		}
+
+		validateModifyGameRoomInformation(modifyGameRoomInformationRequestDto);
+	}
+
+	/**
+	 * 게임방 정보 변경 유효성 검사
+	 *
+	 * @param modifyGameRoomInformationRequestDto
+	 */
+	private void validateModifyGameRoomInformation(ModifyGameRoomInformationRequestDto modifyGameRoomInformationRequestDto) {
+		if (GameRoomInformation.MINIMUM_TITLE_LENGTH.getValue() > modifyGameRoomInformationRequestDto.getTitle().length() ||
+			GameRoomInformation.MAXIMUM_TITLE_LENGTH.getValue() < modifyGameRoomInformationRequestDto.getTitle().length()) {
+			throw new MultiModeException(MultiModeExceptionInfo.INVALID_TITLE_LENGTH);
+		}
+		else if (modifyGameRoomInformationRequestDto.getYear().equals("")) {
+			throw new MultiModeException(MultiModeExceptionInfo.INVALID_YEAR);
+		}
+		else if (modifyGameRoomInformationRequestDto.getQuizAmount() != GameRoomInformation.QUIZ_AMOUNT_3.getValue() &&
+				modifyGameRoomInformationRequestDto.getQuizAmount() != GameRoomInformation.QUIZ_AMOUNT_10.getValue() &&
+				modifyGameRoomInformationRequestDto.getQuizAmount() != GameRoomInformation.QUIZ_AMOUNT_20.getValue() &&
+				modifyGameRoomInformationRequestDto.getQuizAmount() != GameRoomInformation.QUIZ_AMOUNT_30.getValue()) {
+			throw new MultiModeException(MultiModeExceptionInfo.INVALID_QUIZ_AMOUNT);
+		}
+		else if (GameRoomInformation.MINIMUM_MAX_USER_NUMBER.getValue() > modifyGameRoomInformationRequestDto.getMaxUserNumber() ||
+			GameRoomInformation.MAXIMUM_MAX_USER_NUMBER.getValue() < modifyGameRoomInformationRequestDto.getMaxUserNumber()) {
+			throw new MultiModeException(MultiModeExceptionInfo.INVALID_MAX_USER_NUMBER);
 		}
 	}
 

--- a/backend/src/main/java/com/a608/musiq/global/exception/info/MultiModeExceptionInfo.java
+++ b/backend/src/main/java/com/a608/musiq/global/exception/info/MultiModeExceptionInfo.java
@@ -13,7 +13,10 @@ public enum MultiModeExceptionInfo {
     NOT_FOUND_MULTI_MODE_CREATE_GAME_ROOM_LOG(HttpStatus.BAD_REQUEST, 1605, "멀티모드 게임방 생성 로그를 찾을 수 없습니다."),
     NOT_FOUND_MULTI_MODE_GAME_START_LOG(HttpStatus.BAD_REQUEST, 1606, "멀티모드 게임 시작 로그를 찾을 수 없습니다."),
     INVALID_MAX_USER_NUMBER(HttpStatus.BAD_REQUEST, 1607, "최대 인원수가 유효하지 않습니다."),
-    NOT_ALLOWED_USER(HttpStatus.BAD_REQUEST, 1608, "방장만 변경할 수 있습니다.");
+    NOT_ALLOWED_USER(HttpStatus.BAD_REQUEST, 1608, "방장만 변경할 수 있습니다."),
+    INVALID_TITLE_LENGTH(HttpStatus.BAD_REQUEST, 1609, "제목 길이가 유효하지 않습니다."),
+    INVALID_YEAR(HttpStatus.BAD_REQUEST, 1610, "년도가 유효하지 않습니다."),
+    INVALID_QUIZ_AMOUNT(HttpStatus.BAD_REQUEST, 1611, "문제 수가 유효하지 않습니다.");
 
     private final HttpStatus status;
     private final Integer code;


### PR DESCRIPTION
### 1️⃣ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
<br>

### 2️⃣ 이슈 번호
- close #39 
<br>
<br>

### 3️⃣ 변경 사항
- 현재 프론트엔드에서 하고 있는 유효성 검사를 백엔드에서도 동일하게 검사하도록 기능 추가
- 제목 / 1자 ~ 18자
- 년도 / ""
- 문제 수 / 3, 10, 20, 30
- 최대 인원 수 / 1 ~ 10
<br>
<br>

### 4️⃣ 테스트 결과
- postman에서 테스트 완료했습니다.
