### PR TITLE
Fix: 수정 인터셉터 확인 API 경로

### DIFF
--- a/backend/src/main/java/com/a608/musiq/global/config/WebMvcConfig.java
+++ b/backend/src/main/java/com/a608/musiq/global/config/WebMvcConfig.java
@@ -15,7 +15,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(interceptor)
-                .addPathPatterns("/music/single/**", "/chat-message/**", "/member/logout");
+                .addPathPatterns("/music/single/**", "/game/**", "/member/logout");
     }
 
 }


### PR DESCRIPTION
### 1️⃣ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
<br>

### 2️⃣ 이슈 번호
ex) close #69
<br>

### 3️⃣ 변경 사항
- 기존 /chat-message 에서 /game으로 수정하여 멀티 게임 API에서 인터셉터가 확인하도록 변경
- <br>

### 4️⃣ 테스트 결과
포스트맨과 웹소켓 테스트 툴로 테스트해본 결과, HTTP 통신에서는 인터셉터가 잘 동작하는 것으로 확인됨.
그런데 이 인터셉터로는 웹소켓통신에서는 동작하지 않는 것 같지만 원래의 목적이 소켓통신은 확인하지 않는 것이여서 큰 문제는 아닌 듯.

그런데 채팅에서 시작되는 모든 로직이 클라이언트에서 받은 토큰을 이용해 UUID를 뽑아서 쓰는데, 이 토큰의 유효성 검사를 인터셉터에서 하지 않았기 때문에 전처럼 똑같이 UUID로 바꾸는 도중에 에러가 발생함. 이 문제를 위해서는 후에 닉네임으로 UUID를 DB에서 찾거나 아니면 다른 방법을 찾아야 할 것 같음
